### PR TITLE
xprelease

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,11 +14,11 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.06.3
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.06.4
     secrets: inherit
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.06.3
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.06.4
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.06.3
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.06.4
     secrets: inherit

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   # Upload build artifacts as release assets
   release-from-build:
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.06.3
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@main
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
       artifact_pattern: "*.tar.xz"

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -9,10 +9,9 @@ on:
 jobs:
   # Upload build artifacts as release assets
   release-from-build:
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@main
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.06.4
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
-      artifact_pattern: "*.tar.xz"
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
updates to determine platform in release notes

updated: instead of putting SHA256 values for each uploaded build artifact (one per platform), I decided to put all the values in a SHA256SUMS file and only record the SHA256 value for the SHA256SUMS file in the release notes