### PR TITLE
externpro 25.07.4-19-g2221c04

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,11 +14,11 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.4
     secrets: inherit
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.4
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.4
     secrets: inherit

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   # Upload build artifacts as release assets
   release-from-build:
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.4
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.4-19-g2221c04`

## Changes

- Updated `.devcontainer` to externpro `25.07.4-19-g2221c04`
- Previous HEAD: `2f5b25225df7ab85889d01af20d4789652964cfb`
- New HEAD: `2221c04397cfbf9afd425c65a3f1415fbfbda25f`
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: Version updated 25.06.7 → 25.07.4
✓ xprelease.yml: Version updated 25.06.7 → 25.07.4


---

*This PR was created automatically by GitHub Actions*
