### PR TITLE
externpro 25.07.4-21-g4dc8abb

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -4,9 +4,9 @@ permissions:
   pull-requests: write
 on:
   push:
-    branches: [ "dev" ]
+    branches: [xpro]
   pull_request:
-    branches: [ "dev" ]
+    branches: [xpro]
   workflow_dispatch:
 jobs:
   linux:
@@ -14,11 +14,11 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.4
     secrets: inherit
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.4
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.4
     secrets: inherit

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   # Upload build artifacts as release assets
   release-from-build:
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.4
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,7 +387,6 @@ target_include_directories(fmt-header-only
 # Install targets.
 if (FMT_INSTALL)
   if(DEFINED XP_NAMESPACE)
-    set(FMT_CMAKE_DIR ${CMAKE_INSTALL_DATADIR}/cmake)
     set(FMT_NAMESPACE ${XP_NAMESPACE})
     xpExternPackage(REPO_NAME fmt NAMESPACE ${XP_NAMESPACE} ALIAS_NAMESPACE fmt
       TARGETS_FILE fmt-targets LIBRARIES fmt fmt-header-only
@@ -396,6 +395,7 @@ if (FMT_INSTALL)
       DESC "A modern formatting library"
       LICENSE "[MIT](https://github.com/fmtlib/fmt?tab=MIT-1-ov-file#readme 'MIT License')"
       )
+    set(FMT_CMAKE_DIR ${CMAKE_INSTALL_CMAKEDIR})
   else()
   set(FMT_NAMESPACE fmt)
   include(CMakePackageConfigHelpers)


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.4-21-g4dc8abb`

## Changes

- Updated `.devcontainer` to externpro `25.07.4-21-g4dc8abb`
- Previous HEAD: `2f5b25225df7ab85889d01af20d4789652964cfb`
- New HEAD: `4dc8abbe79a92782e08396a45257338308d47847`
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: Version updated 25.06.7 → 25.07.4
✓ xpbuild.yml: Branches updated from template
✓ xprelease.yml: Version updated 25.06.7 → 25.07.4


---

*This PR was created automatically by GitHub Actions*
