### PR TITLE
externpro 25.07.4-25-gcc6fff6

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -4,9 +4,9 @@ permissions:
   pull-requests: write
 on:
   push:
-    branches: [ "dev" ]
+    tags: ["v*"]
   pull_request:
-    branches: [ "dev" ]
+    branches: ["xpro"]
   workflow_dispatch:
 jobs:
   linux:
@@ -14,11 +14,11 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.4
     secrets: inherit
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.4
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.4
     secrets: inherit

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   # Upload build artifacts as release assets
   release-from-build:
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.4
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.4-25-gcc6fff6`

## Changes

- Updated `.devcontainer` to externpro `25.07.4-25-gcc6fff6`
- Previous HEAD: `2f5b25225df7ab85889d01af20d4789652964cfb`
- New HEAD: `cc6fff60d581d9a26ab98c07f5b1a9ca5af11ffc`
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: Version updated 25.06.7 → 25.07.4
✓ xpbuild.yml: push.branches updated from template
✓ xpbuild.yml: push.tags updated from template
✓ xpbuild.yml: pull_request.branches updated from template
✓ xprelease.yml: Version updated 25.06.7 → 25.07.4


---

*This PR was created automatically by GitHub Actions*
