### PR TITLE
externpro 25.07.4-26-ga604d6a

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -4,9 +4,9 @@ permissions:
   pull-requests: write
 on:
   push:
-    branches: [ "dev" ]
+    tags: ["v*"]
   pull_request:
-    branches: [ "dev" ]
+    branches: ["xpro"]
   workflow_dispatch:
 jobs:
   linux:
@@ -14,11 +14,11 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.4
     secrets: inherit
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.4
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.4
     secrets: inherit

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   # Upload build artifacts as release assets
   release-from-build:
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.06.7
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.4
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -1,0 +1,14 @@
+name: Tag Release
+permissions:
+  contents: write
+  issues: write
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  tag:
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
+    uses: externpro/externpro/.github/workflows/tag-release.yml@main
+    with:
+      merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
+      pr_number: ${{ github.event.pull_request.number }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,7 +387,6 @@ target_include_directories(fmt-header-only
 # Install targets.
 if (FMT_INSTALL)
   if(DEFINED XP_NAMESPACE)
-    set(FMT_CMAKE_DIR ${CMAKE_INSTALL_DATADIR}/cmake)
     set(FMT_NAMESPACE ${XP_NAMESPACE})
     xpExternPackage(REPO_NAME fmt NAMESPACE ${XP_NAMESPACE} ALIAS_NAMESPACE fmt
       TARGETS_FILE fmt-targets LIBRARIES fmt fmt-header-only
@@ -396,6 +395,7 @@ if (FMT_INSTALL)
       DESC "A modern formatting library"
       LICENSE "[MIT](https://github.com/fmtlib/fmt?tab=MIT-1-ov-file#readme 'MIT License')"
       )
+    set(FMT_CMAKE_DIR ${CMAKE_INSTALL_CMAKEDIR})
   else()
   set(FMT_NAMESPACE fmt)
   include(CMakePackageConfigHelpers)


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.4-26-ga604d6a`

## Changes

- Updated `.devcontainer` to externpro `25.07.4-26-ga604d6a`
- Previous HEAD: `2f5b25225df7ab85889d01af20d4789652964cfb`
- New HEAD: `a604d6acbaf95e0c29c313612ad534a193bb02e2`
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: Version updated 25.06.7 → 25.07.4
✓ xpbuild.yml: push.branches updated from template
✓ xpbuild.yml: push.tags updated from template
✓ xpbuild.yml: pull_request.branches updated from template
✓ xprelease.yml: Version updated 25.06.7 → 25.07.4
✓ xptag.yml: Created new workflow from template


---

*This PR was created automatically by GitHub Actions*
