### PR TITLE
externpro 25.07.4-47-gb6496dd

### DIFF
--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,2 @@
-tag: v11.2.0.7
-message: "externpro version v11.2.0.7 tag"
+tag: xpv11.2.0.8
+message: "externpro version 11.2.0.8 tag"

--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,0 +1,2 @@
+tag: v11.2.0.7
+message: "externpro version v11.2.0.7 tag"

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -4,7 +4,7 @@ permissions:
   pull-requests: write
 on:
   push:
-    tags: ["v*"]
+    tags: ["xpv*"]
   pull_request:
     branches: ["xpro"]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.4-47-gb6496dd`

## Changes

- Updated `.devcontainer` to externpro `25.07.4-47-gb6496dd`
- Previous HEAD: `a604d6acbaf95e0c29c313612ad534a193bb02e2`
- New HEAD: `b6496dd6fa5b917e620c86f0765d9a0707115828`
- Created `.github/release-tag.yml` (tag: `v11.2.0.7`)
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: push.tags updated from template


---

*This PR was created automatically by GitHub Actions*
