### PR TITLE
externpro 25.07.4-56-g29302b4

### DIFF
--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,2 @@
-tag: xpv11.2.0.8
-message: "externpro version 11.2.0.8 tag"
+tag: xpv11.2.0.9
+message: "externpro version 11.2.0.9 tag"

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -12,3 +12,5 @@ jobs:
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}
+    secrets:
+      workflow_write_token: ${{ secrets.XPUPDATE_TOKEN }}


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.4-56-g29302b4`

## Changes

- Updated `.devcontainer` to externpro `25.07.4-56-g29302b4`
- Previous HEAD: `629468c35b63fc1420091a99b7f046f260a1e7ae`
- New HEAD: `29302b4ed9e33bb18d913ac0d1551238581e372a`
- If you add the \"release:tag\" label, the tag will be \`xpv11.2.0.8\`
  - WARNING: that tag already exists; update \".github/release-tag.yml\" to the next desired tag value
- Updated caller workflows to match templates

### Workflow Update Report

✓ xptag.yml: job secrets updated from template

### Preserved Customizations
🔧 merge_sha: \\${{ github.event.pull_request.merge_commit_sha }}
🔧 pr_number: \\${{ github.event.pull_request.number }}

---

*This PR was created automatically by GitHub Actions*
