### PR TITLE
externpro 25.07.4-60-ge87d2cc

### DIFF
--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -1,4 +1,4 @@
-name: Release
+name: xpRelease
 on:
   workflow_dispatch:
     inputs:
@@ -6,12 +6,21 @@ on:
         description: 'URL of the workflow run containing artifacts to upload (e.g., https://github.com/owner/repo/actions/runs/123456789)'
         required: true
         type: string
+  workflow_run:
+    workflows: ["xpBuild"]
+    types: [completed]
 jobs:
   # Upload build artifacts as release assets
   release-from-build:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        startsWith(github.event.workflow_run.head_branch, 'xpv')
+      )
     uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.4
     with:
-      workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
+      workflow_run_url: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.workflow_run_url || github.event.workflow_run.html_url }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -1,4 +1,4 @@
-name: Tag Release
+name: xpTag
 permissions:
   contents: write
   issues: write

--- a/.github/workflows/xpupdate.yml
+++ b/.github/workflows/xpupdate.yml
@@ -1,4 +1,4 @@
-name: Update externpro
+name: xpUpdate externpro
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.4-60-ge87d2cc`

## Changes

- Updated `.devcontainer` to externpro `25.07.4-60-ge87d2cc`
- Previous HEAD: `29302b4ed9e33bb18d913ac0d1551238581e372a`
- New HEAD: `e87d2cca0ceb4bcd282c063bf032cc6321ba8368`
- If you add the \"release:tag\" label, the tag will be \`xpv11.2.0.9\`
  - WARNING: that tag already exists; update \".github/release-tag.yml\" to the next desired tag value
- Updated caller workflows to match templates

### Workflow Update Report

⚠️ xpbuild.yml: Template drift detected (outside preserved customizations)
✓ xprelease.yml: Synced from template
✓ xptag.yml: Synced from template
✓ xpupdate.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
