### PR TITLE
externpro 25.07.4-64-gf19ccb1

### DIFF
--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,2 @@
-tag: xpv11.2.0.10
-message: "externpro version 11.2.0.10 tag"
+tag: xpv11.2.0.11
+message: "externpro version 11.2.0.11 tag"

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -10,17 +10,33 @@ on:
     workflows: ["xpBuild"]
     types: [completed]
 jobs:
+  dispatch-at-tag:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'xpv')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      -
+        name: Dispatch xpRelease at tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          TAG_REF: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/${{ github.repository }}/actions/workflows/xprelease.yml/dispatches" \
+            -f ref="$TAG_REF" \
+            -f inputs[workflow_run_url]="$RUN_URL"
   # Upload build artifacts as release assets
   release-from-build:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event.workflow_run.conclusion == 'success' &&
-        startsWith(github.event.workflow_run.head_branch, 'xpv')
-      )
+    if: github.event_name == 'workflow_dispatch'
     uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.4
     with:
-      workflow_run_url: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.workflow_run_url || github.event.workflow_run.html_url }}
+      workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.4-64-gf19ccb1`

## Changes

- Updated `.devcontainer` to externpro `25.07.4-64-gf19ccb1`
- Previous HEAD: `b765c02dce47aef4720cd1e81bd016e8fe05ceed`
- New HEAD: `f19ccb183a5ff2dd166230e046fa2765fb51cbe7`
- If you add the \"release:tag\" label, the tag will be \`xpv11.2.0.10\`
  - WARNING: that tag already exists; update \".github/release-tag.yml\" to the next desired tag value
- Updated caller workflows to match templates

### Workflow Update Report

✓ xprelease.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
