### PR TITLE
externpro 25.07.4-66-gc54697d

### DIFF
--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,2 @@
-tag: xpv11.2.0.11
-message: "externpro version 11.2.0.11 tag"
+tag: xpv11.2.0.12
+message: "externpro version 11.2.0.12 tag"


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.4-66-gc54697d`

## Changes

- Updated `.devcontainer` to externpro `25.07.4-66-gc54697d`
- Previous HEAD: `f19ccb183a5ff2dd166230e046fa2765fb51cbe7`
- New HEAD: `c54697d5b4170afb6e1d673447198f3a11dceaf2`
- If you add the \"release:tag\" label, the tag will be \`xpv11.2.0.11\`
  - WARNING: that tag already exists; update \".github/release-tag.yml\" to the next desired tag value
    - https://github.com/externpro/fmt/blob/externpro-update-25.07.4-66-gc54697d-21692887760-1/.github/release-tag.yml

---

*This PR was created automatically by GitHub Actions*
