### PR TITLE
externpro 25.07.4-67-gcface4e

### DIFF
--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,2 @@
-tag: xpv11.2.0.12
-message: "externpro version 11.2.0.12 tag"
+tag: xpv11.2.0.13
+message: "externpro version 11.2.0.13 tag"

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.4
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@main
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.4-67-gcface4e`

## Changes

- Updated `.devcontainer` to externpro `25.07.4-67-gcface4e`
- Previous HEAD: `c54697d5b4170afb6e1d673447198f3a11dceaf2`
- New HEAD: `cface4ef7f6d2d473345c1e0be6f9c0ac79c35ec`
- If you add the \"release:tag\" label, the tag will be \`xpv11.2.0.12\`
  - WARNING: that tag already exists; update \".github/release-tag.yml\" to the next desired tag value
    - https://github.com/externpro/fmt/blob/externpro-update-25.07.4-67-gcface4e-21699500478-1/.github/release-tag.yml

---

*This PR was created automatically by GitHub Actions*
