### PR TITLE
externpro 25.07.5

### DIFF
--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,2 @@
-tag: xpv11.2.0.13
-message: "externpro version 11.2.0.13 tag"
+tag: xpv11.2.0.14
+message: "externpro version 11.2.0.14 tag"

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,11 +14,11 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.4
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.5
     secrets: inherit
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.4
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.5
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.4
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.5
     secrets: inherit

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@main
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.5
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@main
+    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.5
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/xpupdate.yml
+++ b/.github/workflows/xpupdate.yml
@@ -7,6 +7,6 @@ on:
   workflow_dispatch:
 jobs:
   update:
-    uses: externpro/externpro/.github/workflows/update-externpro.yml@main
+    uses: externpro/externpro/.github/workflows/update-externpro.yml@25.07.5
     secrets:
       workflow_write_token: ${{ secrets.XPUPDATE_TOKEN }}


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.5`

## Changes

- Updated `.devcontainer` to externpro `25.07.5`
- Previous HEAD: `cface4ef7f6d2d473345c1e0be6f9c0ac79c35ec`
- New HEAD: `97056a16f30b7c59fd405817fad3f4512ad81908`
- If you add the \"release:tag\" label, the tag will be \`xpv11.2.0.13\`
  - WARNING: that tag already exists; update \".github/release-tag.yml\" to the next desired tag value
    - https://github.com/externpro/fmt/blob/externpro-update-25.07.5-21733731700-1/.github/release-tag.yml
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: Version updated 25.07.4 → 25.07.5
✓ xprelease.yml: Synced from template
✓ xptag.yml: Synced from template
✓ xpupdate.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
