### PR TITLE
externpro 25.07.17-1-g3c6402d

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,0 +1,4 @@
+{
+  "message": "xpro version 11.2.0.116 tag",
+  "tag": "xpv11.2.0.116"
+}

--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,0 @@
-tag: xpv11.2.0.15
-message: "externpro version 11.2.0.15 tag"

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,11 +14,15 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.6
-    secrets: inherit
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.17
+    secrets:
+      automation_token: ${{ secrets.GHCR_TOKEN }}
+    with: {}
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.17
     secrets: inherit
+    with: {}
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.17
     secrets: inherit
+    with: {}

--- a/.github/workflows/xpinit.yml
+++ b/.github/workflows/xpinit.yml
@@ -1,0 +1,12 @@
+name: xpInit externpro
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+on:
+  workflow_dispatch:
+jobs:
+  init:
+    uses: externpro/externpro/.github/workflows/init-externpro.yml@main
+    secrets:
+      automation_token: ${{ secrets.XPRO_TOKEN }}

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.17
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.17
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}
     secrets:
-      workflow_write_token: ${{ secrets.XPUPDATE_TOKEN }}
+      automation_token: ${{ secrets.XPRO_TOKEN }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,6 +3,7 @@
   "include": [
     ".devcontainer/cmake/presets/xpLinuxNinja.json",
     ".devcontainer/cmake/presets/xpDarwinNinja.json",
-    ".devcontainer/cmake/presets/xpWindowsVs2022.json"
+    ".devcontainer/cmake/presets/xpMswVs2022.json",
+    ".devcontainer/cmake/presets/xpMswVs2026.json"
   ]
 }


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.17-1-g3c6402d`

## Changes

- Updated `.devcontainer` to externpro `25.07.17-1-g3c6402d`
- Previous HEAD: `e07eafd5a3f9d27c4a56ebe5fddc4058b332d436`
- New HEAD: `3c6402d9a9a03d3be5ca3862afd3064aeed81ab4`
- Created `.github/release-tag.json` (tag: `xpv11.2.0.116`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv11.2.0.116\`
- Updated caller workflows to match templates
- CMakePresets.json review needed
  - See details below

### Workflow Update Report

- ✓ xpbuild.yml: Synced from template
- ✓ xpinit.yml: Created new workflow from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template

### CMakePresets.json

- Auto-fix: replaced `.devcontainer/cmake/presets/xpWindowsVs2022.json` include and staged `CMakePresets.json`

---

*This PR was created automatically by GitHub Actions*
