### PR TITLE
xpro 12.1.0.1

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,0 +1,4 @@
+{
+  "message": "xpro version 11.2.0.17 tag",
+  "tag": "xpv11.2.0.17"
+}

--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,4 +1,4 @@
 {
-  "message": "xpro version 11.2.0.17 tag",
-  "tag": "xpv11.2.0.17"
+  "message": "xpro version 12.1.0.1 tag",
+  "tag": "xpv12.1.0.1"
 }

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,5 @@
 name: CIFuzz
-on: [pull_request]
+on: [workflow_dispatch]
 
 permissions:
   contents: read

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,6 +1,6 @@
 name: doc
 
-on: [push, pull_request]
+on: [workflow_dispatch]
 
 permissions:
   contents: read

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,6 @@
 name: linux
 
-on: [push, pull_request]
+on: [workflow_dispatch]
 
 permissions:
   contents: read

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,6 @@
 name: macos
 
-on: [push, pull_request]
+on: [workflow_dispatch]
 
 permissions:
   contents: read

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,6 @@
 name: windows
 
-on: [push, pull_request]
+on: [workflow_dispatch]
 
 permissions:
   contents: read

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -1,0 +1,28 @@
+name: xpBuild
+permissions:
+  contents: read
+  pull-requests: write
+on:
+  push:
+    tags: ["xpv*"]
+  pull_request:
+    branches: ["xpro"]
+  workflow_dispatch:
+jobs:
+  linux:
+    permissions:
+      contents: read
+      pull-requests: write
+      packages: write
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.17
+    secrets:
+      automation_token: ${{ secrets.GHCR_TOKEN }}
+    with: {}
+  macos:
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.17
+    secrets: inherit
+    with: {}
+  windows:
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.17
+    secrets: inherit
+    with: {}

--- a/.github/workflows/xpinit.yml
+++ b/.github/workflows/xpinit.yml
@@ -1,0 +1,12 @@
+name: xpInit externpro
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+on:
+  workflow_dispatch:
+jobs:
+  init:
+    uses: externpro/externpro/.github/workflows/init-externpro.yml@main
+    secrets:
+      automation_token: ${{ secrets.XPRO_TOKEN }}

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -1,0 +1,44 @@
+name: xpRelease
+on:
+  workflow_dispatch:
+    inputs:
+      workflow_run_url:
+        description: 'URL of the workflow run containing artifacts to upload (e.g., https://github.com/owner/repo/actions/runs/123456789)'
+        required: true
+        type: string
+  workflow_run:
+    workflows: ["xpBuild"]
+    types: [completed]
+jobs:
+  dispatch-at-tag:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'xpv')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      -
+        name: Dispatch xpRelease at tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          TAG_REF: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/${{ github.repository }}/actions/workflows/xprelease.yml/dispatches" \
+            -f ref="$TAG_REF" \
+            -f inputs[workflow_run_url]="$RUN_URL"
+  # Upload build artifacts as release assets
+  release-from-build:
+    if: github.event_name == 'workflow_dispatch'
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.17
+    with:
+      workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    secrets: inherit

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -1,0 +1,16 @@
+name: xpTag
+permissions:
+  contents: write
+  issues: write
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  tag:
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
+    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.17
+    with:
+      merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets:
+      automation_token: ${{ secrets.XPRO_TOKEN }}

--- a/.github/workflows/xpupdate.yml
+++ b/.github/workflows/xpupdate.yml
@@ -1,0 +1,13 @@
+name: xpUpdate externpro
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+on:
+  workflow_dispatch:
+jobs:
+  update:
+    uses: externpro/externpro/.github/workflows/update-externpro.yml@main
+    secrets:
+      automation_token: ${{ secrets.XPRO_TOKEN }}
+    with: {}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ build/
 cmake_install.cmake
 fmt-*.cmake
 fmt.pc
+run-msbuild.bat
+# externpro
+.env
+_bld*/
+docker-compose.override.yml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".devcontainer"]
+	path = .devcontainer
+	url = https://github.com/externpro/externpro

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8...3.28)
+cmake_minimum_required(VERSION 3.8...3.31)
 
 # Fallback for using newer policies on CMake <3.12.
 if (${CMAKE_VERSION} VERSION_LESS 3.12)
@@ -151,6 +151,7 @@ if (FMT_MASTER_PROJECT AND NOT CMAKE_BUILD_TYPE)
               "CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel.")
 endif ()
 
+set(CMAKE_PROJECT_TOP_LEVEL_INCLUDES .devcontainer/cmake/xproinc.cmake)
 project(FMT CXX)
 include(GNUInstallDirs)
 set_verbose(FMT_INC_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE STRING
@@ -384,6 +385,16 @@ target_include_directories(fmt-header-only
 
 # Install targets.
 if (FMT_INSTALL)
+  if(COMMAND xpExternPackage)
+    xpExternPackage(REPO_NAME fmt
+      TARGETS_FILE fmt-targets LIBRARIES fmt fmt-header-only
+      BASE ${FMT_VERSION} XPDIFF "patch"
+      WEB "https://fmt.dev/" UPSTREAM "github.com/fmtlib/fmt"
+      DESC "A modern formatting library"
+      LICENSE "[MIT](https://github.com/fmtlib/fmt?tab=MIT-1-ov-file#readme 'MIT License')"
+      )
+    set(FMT_CMAKE_DIR ${CMAKE_INSTALL_CMAKEDIR})
+  else()
   include(CMakePackageConfigHelpers)
   set_verbose(FMT_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/fmt CACHE STRING
               "Installation directory for cmake files, a relative path that "
@@ -392,18 +403,22 @@ if (FMT_INSTALL)
   set(version_config ${PROJECT_BINARY_DIR}/fmt-config-version.cmake)
   set(project_config ${PROJECT_BINARY_DIR}/fmt-config.cmake)
   set(pkgconfig ${PROJECT_BINARY_DIR}/fmt.pc)
+  endif()
   set(targets_export_name fmt-targets)
 
   set_verbose(FMT_LIB_DIR ${CMAKE_INSTALL_LIBDIR} CACHE STRING
               "Installation directory for libraries, a relative path that "
               "will be joined to ${CMAKE_INSTALL_PREFIX} or an absolute path.")
 
+  if(NOT COMMAND xpExternPackage)
   set_verbose(FMT_PKGCONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/pkgconfig CACHE STRING
               "Installation directory for pkgconfig (.pc) files, a relative "
               "path that will be joined with ${CMAKE_INSTALL_PREFIX} or an "
               "absolute path.")
+  endif()
 
   # Generate the version, config and target files into the build directory.
+  if(NOT COMMAND xpExternPackage)
   write_basic_package_version_file(
     ${version_config}
     VERSION ${FMT_VERSION}
@@ -420,6 +435,7 @@ if (FMT_INSTALL)
     ${PROJECT_SOURCE_DIR}/support/cmake/fmt-config.cmake.in
     ${project_config}
     INSTALL_DESTINATION ${FMT_CMAKE_DIR})
+  endif()
 
   set(INSTALL_TARGETS fmt fmt-header-only)
 
@@ -444,15 +460,19 @@ if (FMT_INSTALL)
          FILE ${PROJECT_BINARY_DIR}/${targets_export_name}.cmake)
 
   # Install version, config and target files.
+  if(NOT COMMAND xpExternPackage)
   install(FILES ${project_config} ${version_config}
           DESTINATION ${FMT_CMAKE_DIR}
           COMPONENT fmt_core)
+  endif()
   install(EXPORT ${targets_export_name} DESTINATION ${FMT_CMAKE_DIR}
           NAMESPACE fmt::
           COMPONENT fmt_core)
 
+  if(NOT COMMAND xpExternPackage)
   install(FILES "${pkgconfig}" DESTINATION "${FMT_PKGCONFIG_DIR}"
           COMPONENT fmt_core)
+  endif()
 endif ()
 
 function(add_doc_target)
@@ -514,7 +534,7 @@ if (FMT_FUZZ)
 endif ()
 
 set(gitignore ${PROJECT_SOURCE_DIR}/.gitignore)
-if (FMT_MASTER_PROJECT AND EXISTS ${gitignore})
+if (FMT_MASTER_PROJECT AND EXISTS ${gitignore} AND NOT COMMAND xpExternPackage)
   # Get the list of ignored files from .gitignore.
   file (STRINGS ${gitignore} lines)
   list(REMOVE_ITEM lines /doc/html)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,9 @@
+{
+  "version": 8,
+  "include": [
+    ".devcontainer/cmake/presets/xpLinuxNinja.json",
+    ".devcontainer/cmake/presets/xpDarwinNinja.json",
+    ".devcontainer/cmake/presets/xpMswVs2022.json",
+    ".devcontainer/cmake/presets/xpMswVs2026.json"
+  ]
+}

--- a/CMakePresetsBase.json
+++ b/CMakePresetsBase.json
@@ -1,0 +1,16 @@
+{
+  "version": 8,
+  "configurePresets": [
+    {
+      "name": "config-base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/_bld-${presetName}"
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "build-base",
+      "hidden": true
+    }
+  ]
+}

--- a/docker-compose.sh
+++ b/docker-compose.sh
@@ -1,0 +1,1 @@
+.devcontainer/compose.pro.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,1 @@
+.devcontainer/compose.bld.yml


### PR DESCRIPTION
rough sequence of what I did locally to reuse the changes from the xpv11.2.0.17 release to create these commits
```
git switch xpro
git reset --soft 11.2.0
git restore --staged .
git stash
git checkout -b xp12.1.0 12.1.0
git push cm 12.1.0
git branch -D xpro
git branch xpro 12.1.0
git stash pop
git restore --staged .
git add .devcontainer .gitmodules
git commit -m "externpro <git describe --tags>"
git add .github/workflows/xp* .github/release-tag.json
git add CMakePresets* docker-compose.*
git commit -m "externpro init"
git add .github/workflows
git commit -m "upstream workflows, on: workflow_dispatch"
<fix minor conflicts in CMakeLists.txt>
git add CMakeLists.txt
git commit -m "CMakeLists.txt: xproinc, xpExternPackage"
<update .github/release-tag.json>
git add .github/release-tag.json
git commit -m "release-tag: xpv12.1.0.1"
git push cm xp12.1.0
git push --force-with-lease cm xpro
```