### PR TITLE
externpro 25.07.17-18-ge3c0288

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,4 +1,4 @@
 {
-  "message": "xpro version 12.1.0.1 tag",
-  "tag": "xpv12.1.0.1"
+  "message": "xpro version 12.1.0.2 tag",
+  "tag": "xpv12.1.0.2"
 }

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.17
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@main
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.17-18-ge3c0288`

## Changes

- Updated `.devcontainer` to externpro `25.07.17-18-ge3c0288`
- Previous HEAD: `99103519f6f18969b8c293e419885f9cc593927d`
- New HEAD: `e3c02884b53478560a147e6476244901c5a11046`
- Updated `.github/release-tag.json` (tag: `xpv12.1.0.2`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv12.1.0.2\`
- Updated caller workflows to match templates

### Workflow Update Report

- ✓ xprelease.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
