### PR TITLE
cmake: drop generator expressions for MSVC /utf-8 option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,8 +369,8 @@ if (NOT MSVC)
   # Unicode is always supported on compilers other than MSVC.
 elseif (FMT_UNICODE)
   # Unicode support requires compiling with /utf-8.
-  target_compile_options(fmt PUBLIC $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/utf-8>)
-  target_compile_options(fmt-header-only INTERFACE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/utf-8>)
+  target_compile_options(fmt PUBLIC /utf-8)
+  target_compile_options(fmt-header-only INTERFACE /utf-8)
 else ()
   target_compile_definitions(fmt PUBLIC FMT_UNICODE=0)
 endif ()


### PR DESCRIPTION
Replace the MSVC-only generator-expression compile options with a plain `/utf-8` option in the existing MSVC/FMT_UNICODE branch.

resolves https://github.com/externpro/fmt/issues/35
