### PR TITLE
externpro 25.07.17-20-g2bd7400

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,4 +1,4 @@
 {
-  "message": "xpro version 12.1.0.2 tag",
-  "tag": "xpv12.1.0.2"
+  "message": "xpro version 12.1.0.3 tag",
+  "tag": "xpv12.1.0.3"
 }

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,15 +14,15 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.17
+    uses: externpro/externpro/.github/workflows/build-linux.yml@main
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
     with: {}
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.17
+    uses: externpro/externpro/.github/workflows/build-macos.yml@main
     secrets: inherit
     with: {}
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.17
+    uses: externpro/externpro/.github/workflows/build-windows.yml@main
     secrets: inherit
     with: {}


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.17-20-g2bd7400`

## Changes

- Updated `.devcontainer` to externpro `25.07.17-20-g2bd7400`
- Previous HEAD: `e3c02884b53478560a147e6476244901c5a11046`
- New HEAD: `2bd74007e77139eaf41d3ea5401b83bb2e9c5fd6`
- Updated `.github/release-tag.json` (tag: `xpv12.1.0.3`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv12.1.0.3\`
- Updated caller workflows to match templates

### Workflow Update Report

- ✓ xpbuild.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
