### PR TITLE
externpro 25.07.17-33-gb851780

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,4 +1,4 @@
 {
-  "message": "xpro version 12.1.0.3 tag",
-  "tag": "xpv12.1.0.3"
+  "message": "xpro version 12.1.0.4 tag",
+  "tag": "xpv12.1.0.4"
 }


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.17-33-gb851780`

## Changes

- Updated `.devcontainer` to externpro `25.07.17-33-gb851780`
- Previous HEAD: `2bd74007e77139eaf41d3ea5401b83bb2e9c5fd6`
- New HEAD: `b8517807fcc416f75ab8547740e3ca91dd98c3af`
- Updated `.github/release-tag.json` (tag: `xpv12.1.0.4`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv12.1.0.4\`

---

*This PR was created automatically by GitHub Actions*
