### PR TITLE
fmt-config.cmake from xpExternPackage, not project_config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,6 +454,9 @@ if (FMT_INSTALL)
   export(TARGETS ${INSTALL_TARGETS} NAMESPACE fmt::
          FILE ${PROJECT_BINARY_DIR}/${targets_export_name}.cmake)
 
+  if(COMMAND xpExternPackage)
+    unset(project_config)
+  endif()
   # Install version, config and target files.
   install(FILES ${project_config} ${version_config}
           DESTINATION ${FMT_CMAKE_DIR}


### PR DESCRIPTION
cmake: don't install project_config (fmt-config.cmake)
* xpExternPackage() installs fmt-config.cmake (from xpuse.cmake.in)

see issue https://github.com/externpro/externpro/issues/308#issuecomment-4210162967