### PR TITLE
externpro 25.07.18

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,15 +14,15 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@main
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.18
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
     with: {}
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@main
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.18
     secrets: inherit
     with: {}
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@main
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.18
     secrets: inherit
     with: {}

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@main
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.18
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.17
+    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.18
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.18`

## Changes

- Updated `.devcontainer` to externpro `25.07.18`
- Previous HEAD: `b8517807fcc416f75ab8547740e3ca91dd98c3af`
- New HEAD: `331e1b4880485c95da9c48af1c03c76538e75839`
- If you add the \"release:tag\" label, the tag will be \`xpv12.1.0.4\`
- Updated caller workflows to match templates

### Workflow Update Report

- ✓ xpbuild.yml: Synced from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
