### PR TITLE
externpro 25.07.18-17-gcf054a4

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,4 +1,4 @@
 {
-  "message": "xpro version 12.1.0.4 tag",
-  "tag": "xpv12.1.0.4"
+  "message": "xpro version 12.1.0.5 tag",
+  "tag": "xpv12.1.0.5"
 }

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -13,7 +13,7 @@ target_compile_features(gtest PUBLIC cxx_std_11)
 
 find_package(Threads)
 if (Threads_FOUND)
-  target_link_libraries(gtest ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(gtest Threads::Threads)
 else ()
   target_compile_definitions(gtest PUBLIC GTEST_HAS_PTHREAD=0)
 endif ()


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.18-17-gcf054a4`

## Changes

- Updated `.devcontainer` to externpro `25.07.18-17-gcf054a4`
- Previous HEAD: `331e1b4880485c95da9c48af1c03c76538e75839`
- New HEAD: `cf054a4d69edb1a88f5d4ee9354d1a57798a7081`
- Updated `.github/release-tag.json` (tag: `xpv12.1.0.5`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv12.1.0.5\`

---

*This PR was created automatically by GitHub Actions*
