### PR TITLE
fix utf-8 target_compile_options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,8 +368,8 @@ if (NOT MSVC)
   # Unicode is always supported on compilers other than MSVC.
 elseif (FMT_UNICODE)
   # Unicode support requires compiling with /utf-8.
-  target_compile_options(fmt PUBLIC /utf-8)
-  target_compile_options(fmt-header-only INTERFACE /utf-8)
+  target_compile_options(fmt PUBLIC "/utf-8")
+  target_compile_options(fmt-header-only INTERFACE "/utf-8")
 else ()
   target_compile_definitions(fmt PUBLIC FMT_UNICODE=0)
 endif ()


### PR DESCRIPTION
cmake: fix utf-8 target_compile_options

previous commit https://github.com/externpro/fmt/commit/08a3b6632ad4a6fbbf1d20232636b4c5b9ceada2

Windows issue, impacts downstream targets that use fmt