### PR TITLE
externpro 26.01-2-g1ebba86

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,4 +1,4 @@
 {
-  "message": "xpro version 12.1.0.5 tag",
-  "tag": "xpv12.1.0.5"
+  "message": "xpro version 12.1.0.6 tag",
+  "tag": "xpv12.1.0.6"
 }

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,15 +14,15 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.18
+    uses: externpro/externpro/.github/workflows/build-linux.yml@26.01
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
     with: {}
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.18
+    uses: externpro/externpro/.github/workflows/build-macos.yml@26.01
     secrets: inherit
     with: {}
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.18
+    uses: externpro/externpro/.github/workflows/build-windows.yml@26.01
     secrets: inherit
     with: {}

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.18
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@26.01
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.18
+    uses: externpro/externpro/.github/workflows/tag-release.yml@26.01
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,9 +385,12 @@ target_include_directories(fmt-header-only
 # Install targets.
 if (FMT_INSTALL)
   if(COMMAND xpExternPackage)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+      set(optParams FIND_XPRO_CMAKE) # /utf-8 flag disregarded with CPS
+    endif()
     xpExternPackage(REPO_NAME fmt TARGETS_FILE fmt-targets
       LIBRARIES fmt fmt-header-only DEFAULT_TARGETS fmt
-      BASE ${FMT_VERSION} XPDIFF "patch"
+      BASE ${FMT_VERSION} XPDIFF "patch" ${optParams}
       WEB "https://fmt.dev/" UPSTREAM "github.com/fmtlib/fmt"
       DESC "A modern formatting library"
       LICENSE "[MIT](https://github.com/fmtlib/fmt?tab=MIT-1-ov-file#readme 'MIT License')"


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01-2-g1ebba86`

## Changes

- Updated `.devcontainer` to externpro `26.01-2-g1ebba86`
- Previous HEAD: `cf054a4d69edb1a88f5d4ee9354d1a57798a7081`
- New HEAD: `1ebba86da156da38487318be095a089054f28f03`
- Updated `.github/release-tag.json` (tag: `xpv12.1.0.6`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv12.1.0.6\`
- Updated caller workflows to match templates

### Workflow Update Report

- ✓ xpbuild.yml: Synced from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
